### PR TITLE
Added schema import command

### DIFF
--- a/docs/schema-commands.md
+++ b/docs/schema-commands.md
@@ -10,3 +10,4 @@ Manage schemas for tenant.
 |[es-cli schema save](#)   |Save a schema in Enterspeed.   |
 |[es-cli schema deploy](#)   |Deploy a schema to target environment in Enterspeed.   |
 |[es-cli schema clone](#)   |Creates all schemas on tenant as json files on disk, in latest versions under /schemas.  |
+|[es-cli schema import](#)   |Imports all schemas from the /schemas folder on the disk. Will create new schemas and update existing schemas if --override is enabled.  |

--- a/src/Enterspeed.Cli/Commands/Schema/ImportSchemaCommand.cs
+++ b/src/Enterspeed.Cli/Commands/Schema/ImportSchemaCommand.cs
@@ -1,0 +1,138 @@
+﻿using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Text.Json;
+using Enterspeed.Cli.Api.MappingSchema;
+using Enterspeed.Cli.Services.ConsoleOutput;
+using Enterspeed.Cli.Services.FileService;
+using Enterspeed.Cli.Services.FileService.Models;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Enterspeed.Cli.Commands.Schema;
+
+internal class ImportSchemaCommand : Command
+{
+    public ImportSchemaCommand() : base(name: "import", "Imports all schemas from the /schemas folder on the disk. Will create new schemas and update existing schemas if --override is enabled.")
+    {
+        AddOption(new Option<bool>(new[] { "--override", "-o" }, "Override existing schemas"));
+    }
+
+    public new class Handler : BaseCommandHandler, ICommandHandler
+    {
+        private readonly IMediator _mediator;
+        private readonly IOutputService _outputService;
+        private readonly ISchemaFileService _schemaFileService;
+        private readonly ILogger<CreateSchemaCommand> _logger;
+
+        public Handler(IMediator mediator, 
+            IOutputService outputService, 
+            ISchemaFileService schemaFileService, 
+            ILogger<CreateSchemaCommand> logger)
+        {
+            _mediator = mediator;
+            _outputService = outputService;
+            _schemaFileService = schemaFileService;
+            _logger = logger;
+        }
+
+        public bool Override { get; set; }
+
+        public async Task<int> InvokeAsync(InvocationContext context)
+        {
+            var existingSchemas = await _mediator.Send(new QueryMappingSchemasRequest());
+            var schemaFiles = _schemaFileService.GetAllSchemas();
+
+            var successfulImports = 0;
+            var failedImports = 0;
+            foreach (var schemaFile in schemaFiles)
+            {
+                var matchingSchema = existingSchemas.FirstOrDefault(sc => sc.ViewHandle == schemaFile.Alias);
+                var schemaExists = matchingSchema is not null;
+
+                if (schemaExists && Override)
+                {
+                    if (await UpdateExistingSchema(schemaFile, matchingSchema))
+                        successfulImports += 1;
+                    else
+                        failedImports += 1;
+                }
+                else if (!schemaExists)
+                {
+                    if (await CreateNewSchema(schemaFile))
+                        successfulImports += 1;
+                    else
+                        failedImports += 1;
+                }
+            }
+
+            _outputService.Write($"Successfully imported {successfulImports} schema(s).");
+                
+            if (failedImports > 0)
+            {
+                _outputService.Write($"Failed to imported {failedImports} schema(s).");
+            }
+
+            return 0;
+        }
+
+        private async Task<bool> UpdateExistingSchema(SchemaFile schemaFile, QueryMappingSchemaResponse queryMappingSchemaResponse)
+        {
+            var existingSchema = await _mediator.Send(
+                new GetMappingSchemaRequest
+                {
+                    MappingSchemaId = queryMappingSchemaResponse.Id.MappingSchemaGuid
+                }
+            );
+
+            if (existingSchema == null)
+            {
+                _logger.LogError("Schema not found!");
+                return false;
+            }
+            
+            var updateSchemaResponse = await _mediator.Send(new UpdateMappingSchemaRequest
+            {
+                Format = "json",
+                MappingSchemaId = queryMappingSchemaResponse.Id.MappingSchemaGuid,
+                Version = existingSchema.LatestVersion,
+                Schema = JsonSerializer.SerializeToDocument(schemaFile.SchemaBaseProperties, SchemaFileService.SerializerOptions)
+            });
+            
+            _outputService.Write($"Successfully updated schema: {schemaFile.Alias} Version: {updateSchemaResponse.Version}");
+
+            return true;
+        }
+
+        /// <summary>
+        /// As the management API does not support upserts we first creates the empty schema and then updates the schema with content
+        /// </summary>
+        private async Task<bool> CreateNewSchema(SchemaFile schemaFile)
+        {
+            var createSchemaResponse = await _mediator.Send(new CreateMappingSchemaRequest
+            {
+                Name = schemaFile.Alias,
+                ViewHandle = schemaFile.Alias
+            });
+
+            if (createSchemaResponse?.IdValue is null || string.IsNullOrEmpty(createSchemaResponse.MappingSchemaGuid))
+            {
+                _logger.LogError($"Could not create schema: {schemaFile.Alias}");
+                return false;
+            }
+
+            _outputService.Write("Successfully created new schema: " + schemaFile.Alias);
+            
+            var updateSchemaResponse = await _mediator.Send(new UpdateMappingSchemaRequest
+            {
+                Format = "json",
+                MappingSchemaId = createSchemaResponse.MappingSchemaGuid,
+                Version = createSchemaResponse.Version,
+                Schema = JsonSerializer.SerializeToDocument(schemaFile.SchemaBaseProperties, SchemaFileService.SerializerOptions)
+            });
+
+            _outputService.Write($"Successfully updated schema: {schemaFile.Alias} Version: {updateSchemaResponse.Version}");
+
+            return true;
+        }
+    }
+}

--- a/src/Enterspeed.Cli/Commands/Schema/ImportSchemaCommand.cs
+++ b/src/Enterspeed.Cli/Commands/Schema/ImportSchemaCommand.cs
@@ -70,6 +70,7 @@ internal class ImportSchemaCommand : Command
             if (failedImports > 0)
             {
                 _outputService.Write($"Failed to imported {failedImports} schema(s).");
+                return 1;
             }
 
             return 0;

--- a/src/Enterspeed.Cli/Commands/Schema/SchemaCommands.cs
+++ b/src/Enterspeed.Cli/Commands/Schema/SchemaCommands.cs
@@ -11,7 +11,8 @@ namespace Enterspeed.Cli.Commands.Schema
                 new CreateSchemaCommand(),
                 new SaveSchemaCommand(),
                 new DeploySchemaCommand(),
-                new CloneSchemaCommand()
+                new CloneSchemaCommand(),
+                new ImportSchemaCommand()
             };
 
             return command;

--- a/src/Enterspeed.Cli/Services/FileService/ISchemaFileService.cs
+++ b/src/Enterspeed.Cli/Services/FileService/ISchemaFileService.cs
@@ -6,6 +6,7 @@ public interface ISchemaFileService
 {
     void CreateSchema(string alias, string content = null);
     SchemaBaseProperties GetSchema(string alias, string filePath = null);
+    IList<SchemaFile> GetAllSchemas();
     bool SchemaExists(string alias);
     bool SchemaValid(string externalSchema, string schemaAlias);
 }

--- a/src/Enterspeed.Cli/Services/FileService/Models/SchemaFile.cs
+++ b/src/Enterspeed.Cli/Services/FileService/Models/SchemaFile.cs
@@ -1,0 +1,13 @@
+﻿namespace Enterspeed.Cli.Services.FileService.Models;
+
+public class SchemaFile
+{
+    public string Alias { get; }
+    public SchemaBaseProperties SchemaBaseProperties { get; }
+
+    public SchemaFile(string alias, SchemaBaseProperties schemaBaseProperties)
+    {
+        Alias = alias;
+        SchemaBaseProperties = schemaBaseProperties;
+    }
+}


### PR DESCRIPTION
Added command to import all schemas from local disk to a tenant.

It will create alle new schemas and update existing once if you have set the override option.

Command: `schema import -o`

I'm still using the existing management API. But we might look at the management API at some point. It would not only improve the performance of the CLI, it would also make the code more clean and add less load to the management API.