### PR TITLE
Added option to import a single schema

### DIFF
--- a/src/Enterspeed.Cli/Commands/Schema/ImportSchemaCommand.cs
+++ b/src/Enterspeed.Cli/Commands/Schema/ImportSchemaCommand.cs
@@ -14,6 +14,7 @@ internal class ImportSchemaCommand : Command
 {
     public ImportSchemaCommand() : base(name: "import", "Imports all schemas from the /schemas folder on the disk. Will create new schemas and update existing schemas if --override is enabled.")
     {
+        AddOption(new Option<string>(new[] { "--schemaAlias", "-a" }, "Provide a schema alias to only import a single schema"));
         AddOption(new Option<bool>(new[] { "--override", "-o" }, "Override existing schemas"));
     }
 
@@ -36,11 +37,15 @@ internal class ImportSchemaCommand : Command
         }
 
         public bool Override { get; set; }
+        public string SchemaAlias { get; set; }
 
         public async Task<int> InvokeAsync(InvocationContext context)
         {
             var existingSchemas = await _mediator.Send(new QueryMappingSchemasRequest());
-            var schemaFiles = _schemaFileService.GetAllSchemas();
+            
+            var schemaFiles = string.IsNullOrWhiteSpace(SchemaAlias) 
+                ? _schemaFileService.GetAllSchemas() 
+                : new List<SchemaFile> { _schemaFileService.GetSchema(SchemaAlias) };
 
             var successfulImports = 0;
             var failedImports = 0;

--- a/src/Enterspeed.Cli/Commands/Schema/SaveSchemaCommand.cs
+++ b/src/Enterspeed.Cli/Commands/Schema/SaveSchemaCommand.cs
@@ -14,7 +14,7 @@ namespace Enterspeed.Cli.Commands.Schema
     {
         public SaveSchemaCommand() : base(name: "save", "Saves schema")
         {
-            AddArgument(new Argument<string>("alias", "Alias of the schema") { });
+            AddArgument(new Argument<string>("alias", "Alias of the schema"));
             AddOption(new Option<string>(new[] { "--file", "-f" }, "E.g. mySchemaAlias.json"));
         }
 
@@ -28,12 +28,12 @@ namespace Enterspeed.Cli.Commands.Schema
             public Handler(
                 IMediator mediator,
                 IOutputService outputService,
-                ISchemaFileService schmeaFileService,
+                ISchemaFileService schemaFileService,
                 ILogger<SaveSchemaCommand> logger)
             {
                 _mediator = mediator;
                 _outputService = outputService;
-                _schemaFileService = schmeaFileService;
+                _schemaFileService = schemaFileService;
                 _logger = logger;
             }
 
@@ -47,7 +47,7 @@ namespace Enterspeed.Cli.Commands.Schema
                     throw new ConsoleArgumentException("Please specify an alias for your schema");
                 }
 
-                var schema = _schemaFileService.GetSchema(Alias, File);
+                var schema = _schemaFileService.GetSchema(Alias, File)?.SchemaBaseProperties;
                 if (schema == null)
                 {
                     _logger.LogError("Schema file not found!");
@@ -77,7 +77,7 @@ namespace Enterspeed.Cli.Commands.Schema
                 }
 
                 // Create update schema request
-                var updateSchemaResponse = await _mediator.Send(new UpdateMappingSchemaRequest()
+                var updateSchemaResponse = await _mediator.Send(new UpdateMappingSchemaRequest
                 {
                     Format = "json",
                     MappingSchemaId = existingSchema.Version.Id.MappingSchemaGuid,

--- a/src/Enterspeed.Cli/Services/FileService/ISchemaFileService.cs
+++ b/src/Enterspeed.Cli/Services/FileService/ISchemaFileService.cs
@@ -5,7 +5,7 @@ namespace Enterspeed.Cli.Services.FileService;
 public interface ISchemaFileService
 {
     void CreateSchema(string alias, string content = null);
-    SchemaBaseProperties GetSchema(string alias, string filePath = null);
+    SchemaFile GetSchema(string alias, string filePath = null);
     IList<SchemaFile> GetAllSchemas();
     bool SchemaExists(string alias);
     bool SchemaValid(string externalSchema, string schemaAlias);

--- a/src/Enterspeed.Cli/Services/FileService/SchemaFileService.cs
+++ b/src/Enterspeed.Cli/Services/FileService/SchemaFileService.cs
@@ -65,10 +65,12 @@ namespace Enterspeed.Cli.Services.FileService
             }
         }
 
-        public SchemaBaseProperties GetSchema(string alias, string filePath = null)
+        public SchemaFile GetSchema(string alias, string filePath = null)
         {
             var schemaFile = GetSchemaContent(alias, filePath);
-            return JsonSerializer.Deserialize<SchemaBaseProperties>(schemaFile, SerializerOptions);
+            var schemaBaseProperties = JsonSerializer.Deserialize<SchemaBaseProperties>(schemaFile, SerializerOptions);
+
+            return new SchemaFile(alias, schemaBaseProperties);
         }
 
         public IList<SchemaFile> GetAllSchemas()
@@ -80,9 +82,8 @@ namespace Enterspeed.Cli.Services.FileService
             return filePaths.Select(filePath =>
             {
                 var alias = GetAliasFromFilePath(filePath);
-                var schemaBaseProperties = GetSchema(alias, filePath);
 
-                return new SchemaFile(alias, schemaBaseProperties);
+                return GetSchema(alias, filePath);
             })
             .ToList();
         }


### PR DESCRIPTION
The option to import a single schema makes it easier to work with the schemas locally as you don't have to call create and the save when creating new schemas. The import command does both in one call