### PR TITLE
Fixed create source command

### DIFF
--- a/src/Enterspeed.Cli/Api/Source/CreateSource.cs
+++ b/src/Enterspeed.Cli/Api/Source/CreateSource.cs
@@ -9,10 +9,11 @@ public class CreateSourceRequest : IRequest<CreateSourceResponse>
     public string SourceGroupId { get; }
     public string Name { get; set; }
     public string Type { get; set; }
+    public string[] EnvironmentIds { get; set; }
 
     public CreateSourceRequest(SourceGroupId sourceGroupId)
     {
-        SourceGroupId = sourceGroupId.SourceGroupGuid;
+        SourceGroupId = sourceGroupId.IdValue;
     }
 }
 

--- a/src/Enterspeed.Cli/Commands/Source/CreateSourceCommand.cs
+++ b/src/Enterspeed.Cli/Commands/Source/CreateSourceCommand.cs
@@ -12,7 +12,8 @@ public class CreateSourceCommand : Command
     {
         AddArgument(new Argument<Guid>("id", "Id of the source group") { Arity = ArgumentArity.ExactlyOne });
         AddOption(new Option<string>(new[] { "--name", "-n" }, "Name of source group") { IsRequired = true });
-        AddOption(new Option<string>(new[] { "--type", "-t" }, "Source group type"));
+        AddOption(new Option<string[]>(new[] { "--environment", "-e" }, "Target environment for deploy") { IsRequired = true });
+        AddOption(new Option<string>(new[] { "--type", "-t" }, "Source group type") { IsRequired = true });
     }
 
     public new class Handler : BaseCommandHandler, ICommandHandler
@@ -22,6 +23,7 @@ public class CreateSourceCommand : Command
 
         public Guid Id { get; set; }
         public string Name { get; set; }
+        public string[] Environment { get; set; }
         public string Type { get; set; }
 
         public Handler(IMediator mediator, IOutputService outputService)
@@ -35,7 +37,8 @@ public class CreateSourceCommand : Command
             var request = new CreateSourceRequest(SourceGroupId.Parse(SourceGroupId.From(Id.ToString())))
             {
                 Name = Name,
-                Type = Type
+                Type = Type,
+                EnvironmentIds = Environment
             };
 
             var domain = await _mediator.Send(request);


### PR DESCRIPTION
The create source command is missing required environments and is passing source group guid value instead of gid value. Also type is required in the management API.