### PR TITLE
Improve consistent commands naming

### DIFF
--- a/src/Enterspeed.Cli/Commands/SourceGroup/ListSourceGroupsCommand.cs
+++ b/src/Enterspeed.Cli/Commands/SourceGroup/ListSourceGroupsCommand.cs
@@ -6,9 +6,9 @@ using Enterspeed.Cli.Api.SourceGroup;
 
 namespace Enterspeed.Cli.Commands.SourceGroup;
 
-public class ListSourceGroupCommand : Command
+public class ListSourceGroupsCommand : Command
 {
-    public ListSourceGroupCommand() : base(name: "list", "List source groups")
+    public ListSourceGroupsCommand() : base(name: "list", "List source groups")
     {
     }
 

--- a/src/Enterspeed.Cli/Commands/SourceGroup/SourceGroupCommands.cs
+++ b/src/Enterspeed.Cli/Commands/SourceGroup/SourceGroupCommands.cs
@@ -8,7 +8,7 @@ public static class SourceGroupCommands
     {
         var command = new Command("source-group", "Source group")
         {
-            new ListSourceGroupCommand(),
+            new ListSourceGroupsCommand(),
             new CreateSourceGroupCommand(),
             new UpdateSourceGroupCommand(),
             new DeleteSourceGroupCommand()

--- a/src/Enterspeed.Cli/Commands/View/ViewCommands.cs
+++ b/src/Enterspeed.Cli/Commands/View/ViewCommands.cs
@@ -6,7 +6,7 @@ public static class ViewCommands
 {
     public static Command BuildCommands()
     {
-        var command = new Command("views", "Generated views")
+        var command = new Command("view", "Generated views")
         {
             new ListViewsCommand()
         };


### PR DESCRIPTION
All other root command names are singular. Subcommands of `List{Something}` is always in plural.