### PR TITLE
Chore/consistent argument and option naming

### DIFF
--- a/docs/views-commands.md
+++ b/docs/views-commands.md
@@ -13,21 +13,21 @@ Query views.
 Query generated views.
 
 ```bash
-es-cli view list <EnvironmentId> [--SourceId] 
-                                 [--SchemaAlias]
-                                 [--OriginId] 
+es-cli view list <environmentId> [--source-id] 
+                                 [--schema-alias]
+                                 [--origin-id] 
 ```
 
 #### Required Parameters
-`EnvironmentId`
+`environmentId`
 
 Id of environment to query.
 
 
 #### Optional Parameters
 
-`--SourceId`
+`--source-id`
 
-`--SchemaAlias`
+`--schema-alias`
 
-`--OriginId`
+`--origin-id`

--- a/src/Enterspeed.Cli/Commands/Deploy/DeployCommand.cs
+++ b/src/Enterspeed.Cli/Commands/Deploy/DeployCommand.cs
@@ -14,10 +14,10 @@ namespace Enterspeed.Cli.Commands.Deploy;
 
 public class DeployCommand : Command
 {
-    public DeployCommand() : base(name: "deploy", "Deploy schemas using deploymentplan")
+    public DeployCommand() : base(name: "deploy", "Deploy schemas using deployment plan")
     {
         AddOption(new Option<string>(new[] { "--environment", "-e" }, "Target environment for deploy") { IsRequired = true });
-        AddOption(new Option<string>(new[] { "--deploymentplan", "-dp" }, "Deployment plan to use"));
+        AddOption(new Option<string>(new[] { "--deployment-plan", "-dp" }, "Deployment plan to use"));
     }
 
     public new class Handler : BaseCommandHandler, ICommandHandler

--- a/src/Enterspeed.Cli/Commands/Schema/ImportSchemaCommand.cs
+++ b/src/Enterspeed.Cli/Commands/Schema/ImportSchemaCommand.cs
@@ -15,7 +15,7 @@ internal class ImportSchemaCommand : Command
 {
     public ImportSchemaCommand() : base(name: "import", "Imports all schemas from the /schemas folder on the disk. Will create new schemas and update existing schemas if --override is enabled.")
     {
-        AddOption(new Option<string>(new[] { "--schemaAlias", "-a" }, "Provide a schema alias to only import a single schema"));
+        AddOption(new Option<string>(new[] { "--schema-alias", "-a" }, "Provide a schema alias to only import a single schema"));
         AddOption(new Option<bool>(new[] { "--override", "-o" }, "Override existing schemas"));
     }
 

--- a/src/Enterspeed.Cli/Commands/SourceEntity/DeleteSourceEntityCommand.cs
+++ b/src/Enterspeed.Cli/Commands/SourceEntity/DeleteSourceEntityCommand.cs
@@ -14,7 +14,7 @@ public class DeleteSourceEntitiesCommand : Command
     public DeleteSourceEntitiesCommand() : base(name: "delete", "Delete source entity")
     {
         AddArgument(new Argument<string>("id", "Id of the source entity to delete") { Arity = ArgumentArity.ExactlyOne });
-        AddOption(new Option<string>(new[] { "--sourceId", "-s" }, "Id of the source, if not using full source entity id") { Arity = ArgumentArity.ZeroOrOne });
+        AddOption(new Option<string>(new[] { "--source-id", "-s" }, "Id of the source, if not using full source entity id") { Arity = ArgumentArity.ZeroOrOne });
     }
 
     public new class Handler : BaseCommandHandler, ICommandHandler

--- a/src/Enterspeed.Cli/Commands/SourceEntity/IngestSourceEntititesCommand.cs
+++ b/src/Enterspeed.Cli/Commands/SourceEntity/IngestSourceEntititesCommand.cs
@@ -12,7 +12,7 @@ namespace Enterspeed.Cli.Commands.SourceEntity
     {
         public IngestSourceEntitiesCommand() : base(name: "ingest", "Ingest source entities")
         {
-            AddArgument(new Argument<string>("FilePath", "File or path to ingest") {Arity = ArgumentArity.ExactlyOne});
+            AddArgument(new Argument<string>("filePath", "File or path to ingest") {Arity = ArgumentArity.ExactlyOne});
             AddOption(new Option<string>(new [] { "--sourceId", "-s" }, "Id of the source") { Arity = ArgumentArity.ExactlyOne });
             AddOption(new Option<bool>( new [] { "--filenameAsId", "-fid" }, "Use filename as id"));
         }

--- a/src/Enterspeed.Cli/Commands/SourceEntity/IngestSourceEntititesCommand.cs
+++ b/src/Enterspeed.Cli/Commands/SourceEntity/IngestSourceEntititesCommand.cs
@@ -13,8 +13,8 @@ namespace Enterspeed.Cli.Commands.SourceEntity
         public IngestSourceEntitiesCommand() : base(name: "ingest", "Ingest source entities")
         {
             AddArgument(new Argument<string>("filePath", "File or path to ingest") {Arity = ArgumentArity.ExactlyOne});
-            AddOption(new Option<string>(new [] { "--sourceId", "-s" }, "Id of the source") { Arity = ArgumentArity.ExactlyOne });
-            AddOption(new Option<bool>( new [] { "--filenameAsId", "-fid" }, "Use filename as id"));
+            AddOption(new Option<string>(new [] { "--source-id", "-s" }, "Id of the source") { Arity = ArgumentArity.ExactlyOne });
+            AddOption(new Option<bool>( new [] { "--filename-as-id", "-fid" }, "Use filename as id"));
         }
 
         public new class Handler : BaseCommandHandler, ICommandHandler

--- a/src/Enterspeed.Cli/Commands/SourceEntity/ListSourceEntitiesCommand.cs
+++ b/src/Enterspeed.Cli/Commands/SourceEntity/ListSourceEntitiesCommand.cs
@@ -11,8 +11,8 @@ public class ListSourceEntitiesCommand : Command
     public ListSourceEntitiesCommand() : base(name: "list", "List source entities")
     {
         AddArgument(new Argument<string>("sourceId", "Id of the source") { Arity = ArgumentArity.ExactlyOne });
-        AddOption(new Option<string>("--Filter", "Filter on ID or Url"));
-        AddOption(new Option<string>("--Type", "Source Entity type"));
+        AddOption(new Option<string>("--filter", "Filter on ID or Url"));
+        AddOption(new Option<string>("--type", "Source Entity type"));
     }
 
     public new class Handler : BaseCommandHandler, ICommandHandler

--- a/src/Enterspeed.Cli/Commands/SourceEntity/ListSourceEntitiesCommand.cs
+++ b/src/Enterspeed.Cli/Commands/SourceEntity/ListSourceEntitiesCommand.cs
@@ -10,7 +10,7 @@ public class ListSourceEntitiesCommand : Command
 {
     public ListSourceEntitiesCommand() : base(name: "list", "List source entities")
     {
-        AddArgument(new Argument<string>("SourceId", "Id of the source") { Arity = ArgumentArity.ExactlyOne });
+        AddArgument(new Argument<string>("sourceId", "Id of the source") { Arity = ArgumentArity.ExactlyOne });
         AddOption(new Option<string>("--Filter", "Filter on ID or Url"));
         AddOption(new Option<string>("--Type", "Source Entity type"));
     }

--- a/src/Enterspeed.Cli/Commands/View/ListViewsCommand.cs
+++ b/src/Enterspeed.Cli/Commands/View/ListViewsCommand.cs
@@ -10,7 +10,7 @@ public class ListViewsCommand : Command
 {
     public ListViewsCommand() : base(name: "list", "List views")
     {
-        AddArgument(new Argument<string>("EnvironmentId", "Id of the environment") { Arity = ArgumentArity.ExactlyOne });
+        AddArgument(new Argument<string>("environmentId", "Id of the environment") { Arity = ArgumentArity.ExactlyOne });
         AddOption(new Option<string>("--SourceId", "Source ID"));
         AddOption(new Option<string>("--SchemaAlias", "Schema Alias"));
         AddOption(new Option<string>("--OriginId", "Source Entity Origin ID"));

--- a/src/Enterspeed.Cli/Commands/View/ListViewsCommand.cs
+++ b/src/Enterspeed.Cli/Commands/View/ListViewsCommand.cs
@@ -11,9 +11,9 @@ public class ListViewsCommand : Command
     public ListViewsCommand() : base(name: "list", "List views")
     {
         AddArgument(new Argument<string>("environmentId", "Id of the environment") { Arity = ArgumentArity.ExactlyOne });
-        AddOption(new Option<string>("--SourceId", "Source ID"));
-        AddOption(new Option<string>("--SchemaAlias", "Schema Alias"));
-        AddOption(new Option<string>("--OriginId", "Source Entity Origin ID"));
+        AddOption(new Option<string>("--source-id", "Source ID"));
+        AddOption(new Option<string>("--schema-alias", "Schema Alias"));
+        AddOption(new Option<string>("--origin-id", "Source Entity Origin ID"));
     }
 
     public new class Handler : BaseCommandHandler, ICommandHandler


### PR DESCRIPTION
I'm not entirely sure from looking at the source code what is the naming pattern that we are following, I attempted to generalize common naming patterns we have used so far, based from overview - attached screenshots.

![Screenshot 2023-08-24 234143](https://github.com/enterspeedhq/enterspeed-cli/assets/9888785/315e6a4f-6cbe-4b38-8d0f-e19e7a72e9b6)
![Screenshot 2023-08-24 234249](https://github.com/enterspeedhq/enterspeed-cli/assets/9888785/9c9249bc-e5fd-491e-a7ec-d2b70db611af)

Outcome:
Arguments (not sure if that is ever visible?) - camel case.
Options - kebab-case. 